### PR TITLE
chore: rename devops-ci to platform-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,18 +9,18 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                               @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/.github/                                               @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                             @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                              @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+/README.md                                              @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/developer-advocates
 **/LICENSE                                              @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                          @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/codecov.yml                                          @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                           @hashgraph/devops-ci @hashgraph/developer-advocates
+**/.gitignore                                           @hashgraph/platform-ci @hashgraph/developer-advocates
 **/.gitignore.*                                         @hashgraph/developer-advocates


### PR DESCRIPTION
Description:

Rename devops-ci to platform-ci and devops-ci-committers to platform-ci-committers

Related Issue(s):

Fixes #49
